### PR TITLE
Let the user parse a file from the Python API.

### DIFF
--- a/python3/fxtran.c
+++ b/python3/fxtran.c
@@ -6,10 +6,10 @@ static PyObject * fxtran_Error = NULL;
 static PyObject * run (PyObject * self, PyObject * args, PyObject * kwargs)
 {
   if(!kwargs)
-	{
+    {
     PyErr_SetString(PyExc_RuntimeError, "Need to specify either 'code=' or 'file=' argument");
     return NULL;
-  }
+    }
 
   Py_ssize_t items = PyTuple_Size (args);
   int argc = items + 2;
@@ -19,37 +19,33 @@ static PyObject * run (PyObject * self, PyObject * args, PyObject * kwargs)
 
   argv[0] = "";
   for(Py_ssize_t i=0;i<items;i++)
-	{
+    {
     PyObject * arg = PyTuple_GetItem (args, i);
     str[i] = PyObject_Str (arg);
     argv[i+1] = (char*)PyUnicode_AsUTF8 (str[i]);
-  }
+    }
 
   PyObject *file_item = Py_BuildValue("s", "file");
   PyObject *file = PyDict_GetItem(kwargs, file_item);
   if(file)
-	{
+    {
     PyObject *file_str = PyObject_Str(file);
     argv[argc-1] = (char*)PyUnicode_AsUTF8(file_str);
-  }
+    }
 
   PyObject *code_item = Py_BuildValue("s", "code");
   PyObject *code = PyDict_GetItem(kwargs, code_item);
   if(code)
-	{
+    {
     PyObject *code_str = PyObject_Str(code);
     Text = (char*)PyUnicode_AsUTF8(code_str);
     argv[argc-1] = "_.F90";
-  }
+    }
 
   if(Text)
-	{
     FXTRAN_RUN (argc, argv, Text, &Xml, &Err);
-  }
-	else
-	{
+  else
     FXTRAN_RUN (argc, argv, NULL, &Xml, &Err);
-  }
 
   for (Py_ssize_t i = 0; i < items; i++)
     Py_DECREF (str[i]);

--- a/python3/fxtran.c
+++ b/python3/fxtran.c
@@ -3,35 +3,55 @@
 
 static PyObject * fxtran_Error = NULL;
 
-static PyObject * run (PyObject * self, PyObject * args)   
+static PyObject * run (PyObject * self, PyObject * args, PyObject * kwargs)
 {
+  if(!kwargs)
+	{
+    PyErr_SetString(PyExc_RuntimeError, "Need to specify either 'code=' or 'file=' argument");
+    return NULL;
+  }
+
   Py_ssize_t items = PyTuple_Size (args);
-  int argc = items + 1;
+  int argc = items + 2;
   char * argv[argc];
   char * Text = NULL, * Xml = NULL, * Err = NULL;
   PyObject * str[items], * ret = NULL;
-  Py_ssize_t i;
 
   argv[0] = "";
-  for (i = 0; i < items; i++) 
-    {   
-      PyObject * arg = PyTuple_GetItem (args, i); 
+  for(Py_ssize_t i=0;i<items;i++)
+	{
+    PyObject * arg = PyTuple_GetItem (args, i);
+    str[i] = PyObject_Str (arg);
+    argv[i+1] = (char*)PyUnicode_AsUTF8 (str[i]);
+  }
 
-      if (arg == NULL) 
-        return 0;
+  PyObject *file_item = Py_BuildValue("s", "file");
+  PyObject *file = PyDict_GetItem(kwargs, file_item);
+  if(file)
+	{
+    PyObject *file_str = PyObject_Str(file);
+    argv[argc-1] = (char*)PyUnicode_AsUTF8(file_str);
+  }
 
-      str[i] = PyObject_Str (arg);
+  PyObject *code_item = Py_BuildValue("s", "code");
+  PyObject *code = PyDict_GetItem(kwargs, code_item);
+  if(code)
+	{
+    PyObject *code_str = PyObject_Str(code);
+    Text = (char*)PyUnicode_AsUTF8(code_str);
+    argv[argc-1] = "_.F90";
+  }
 
-      if (i < argc-2)
-        argv[i+1] = (char*)PyUnicode_AsUTF8 (str[i]);
-      else
-        Text = (char*)PyUnicode_AsUTF8 (str[i]);
-    }
-  argv[argc-1] = "_.F90";
+  if(Text)
+	{
+    FXTRAN_RUN (argc, argv, Text, &Xml, &Err);
+  }
+	else
+	{
+    FXTRAN_RUN (argc, argv, NULL, &Xml, &Err);
+  }
 
-  FXTRAN_RUN (argc, argv, Text, &Xml, &Err);
-
-  for (i = 0; i < items; i++)
+  for (Py_ssize_t i = 0; i < items; i++)
     Py_DECREF (str[i]);
 
   if (Err)
@@ -52,14 +72,21 @@ static PyObject * run (PyObject * self, PyObject * args)
 
 static PyMethodDef fxtran_Methods[] =
 {
-  {"run", run,    METH_VARARGS,   ""},
+  {
+    "run",
+    (PyCFunctionWithKeywords)run,
+    METH_VARARGS|METH_KEYWORDS,
+    "Generate XML with fxtran from a string or a file\n"\
+    "fxtran.run('-canonic', code=\"PROGRAM MAIN\\nEND\")\n"\
+    "fxtran.run('-canonic', file=\"main.F90\")"\
+  },
   {NULL,  NULL,   0,            NULL}
 };
 
 static struct PyModuleDef fxtran_Module =
 {
   PyModuleDef_HEAD_INIT,
-  "fxtran", 
+  "fxtran",
   "",          
   -1,          
   fxtran_Methods


### PR DESCRIPTION
For now, parsing file containing preprocessors directives through the python API seems broken.
For instance with this file:
```
subroutine f()
#ifdef FOO
if(.true.)then
#else
if(.false.)then
#endif
endif
end subroutine f
```

It works fine when using fxtran, but when using the python wrapper the parsing fail:
```
Traceback (most recent call last):
  File "/tmp/fxtran/main.py", line 8, in <module>
    xml=fxtran.run('-canonic','-DFOO','-cpp',code)
fxtran.error: 
E.</literal-E></condition-E>) THEN</if-then-stmt>
<cpp>#endif</cpp>
<end-if-stmt>ENDIF</end-if-stmt>
At FXTRAN_STMT.c:3200
Unexpected end-subroutine-stmt statement
      | 0         1         2         3         4         5         6         7         

    5 | if(.false.)then
    6 | #endif
    7 | endif
    8 | end subroutine f
            ^
```

The problem seems to arise because the code is never preprocessed.  Indeed, when FXTRAN_RUN is called with the 'Text' variable being not NULL, the preprocessor is never called. The preprocessor is only called when a file is given.
In consequence this problem can be fixed in the Python API by letting the user provide a file instead of a string containing the code. It will be then fxtran's job to open the file and fxtran will preprocess it.

It also ease the use of the Python API since the user don't have to open a file and read it on the python side just to give it to fxtran. The user can now just give a filename and get the resulting xml.
